### PR TITLE
fix problem with litemaas db innitialization

### DIFF
--- a/docs/11-maas/2-deploy-litemaas.md
+++ b/docs/11-maas/2-deploy-litemaas.md
@@ -102,7 +102,7 @@ litemaas/
 
 We are going to use the Helm recipe to deploy LiteMaaS, with a few configuration values.
 
-Under `litemaas/deployment/helm/litemaas` folder, create a copy of the file `values.yaml`:
+1. Under `litemaas/deployment/helm/litemaas` folder, create a copy of the file `values.yaml`:
 
 ```bash
 cd deployment/helm/litemaas
@@ -112,6 +112,20 @@ cp values.yaml my-values.yaml
 Edit the file and modify all the `changeme` field for more robust passwords.
 
 > ⚠️ **Note:** In a real deployment, you'd use proper secrets management (e.g., External Secrets Operator, Vault). For now, we're keeping it simple, but we will come to this topic very soon :)
+
+2. We need to activate DB Schema configuration by upgrading the litemaas chart, go to `templates/litellm-deployment.yaml` and update to this:
+
+```yaml
+            - name: STORE_MODEL_IN_DB
+              value: "True"
+            - name: DISABLE_SCHEMA_UPDATE
+              value: "false"  # 👈 Modify this line to define "false" == Activate DB Schema Update ❗︎❗︎
+            - name: REDIS_HOST
+              value: "release-name-litemaas-redis"
+            - name: REDIS_PORT
+              value: "6379"
+              
+```
 
 ---
 


### PR DESCRIPTION
**Situation**: 

An error appears on the LiteMaaS dashboard when attempting to register a model, despite the configuration appearing correct. The issue appears to be missing tables within the database schema... 😞

<img width="1506" height="822" alt="Screenshot 2026-03-27 at 13 03 47" src="https://github.com/user-attachments/assets/4a4998d1-a978-4af7-9d06-a53a4e5deea0" />

<img width="1486" height="822" alt="Screenshot 2026-03-27 at 14 31 05" src="https://github.com/user-attachments/assets/661391e7-f593-462c-8877-7ffc332b2417" />

<img width="1189" height="638" alt="Screenshot 2026-03-27 at 14 31 30" src="https://github.com/user-attachments/assets/2ff28a5c-dec6-4748-95d0-b68ca9a221b5" />

<img width="1187" height="710" alt="Screenshot 2026-03-27 at 14 31 54" src="https://github.com/user-attachments/assets/e63658e5-7563-4e52-b98c-7b07e55fa591" />


**Workaround/Solution**:

We activate LiteMaaS DB Schema update in the Helm Chart in order to populate the DB... 🥳

<img width="1502" height="823" alt="Screenshot 2026-03-27 at 14 45 19" src="https://github.com/user-attachments/assets/398de80c-d2a0-406d-84eb-7666d4662903" />

<img width="1189" height="694" alt="Screenshot 2026-03-27 at 14 49 18" src="https://github.com/user-attachments/assets/c4f9b917-3c1a-4dcc-a165-706dd9143973" />

<img width="1177" height="710" alt="Screenshot 2026-03-27 at 14 54 26" src="https://github.com/user-attachments/assets/b19dc905-eb65-45bb-9da4-a97bc4a751ae" />



