### PR TITLE
Fix summarization typo

### DIFF
--- a/docs/10-model-optimization/5-update-canopy.md
+++ b/docs/10-model-optimization/5-update-canopy.md
@@ -29,7 +29,7 @@ Let's take our experiment environment from Tiny Llama and point it to the FP8 on
 6.  We need to change every `llama32` and/or `tinyllama` to `llama32-fp8`. And we can bump the `max_token` again. For `summarize`:
 
     ```yaml
-    summarize:
+    summarization:
       enabled: true
       mlflow_prompt_version: latest
       mlflow_prompt: summarization
@@ -73,7 +73,7 @@ Once Llama Stack and backend are running, let's verify it can communicate with t
     ```yaml
 
     LLAMA_STACK_URL: "http://llama-stack-service:8321"
-    summarize:
+    summarization:
       enabled: true
       model: vllm-llama32-fp8/llama32-fp8 # 👈 Update this  ❗︎❗︎
     information-search:

--- a/docs/11-maas/3-canopy-integration.md
+++ b/docs/11-maas/3-canopy-integration.md
@@ -103,7 +103,7 @@ Like we've done multiple times before, let's update Canopy backend configuration
 2.  We need to change every `llama32-fp8` into MaaS provided version of that model :) For example, for  `summarize`:
 
     ```yaml
-    summarize:
+    summarization:
       enabled: true
       max_tokens: 2048 
       model: vllm-Llama-3.2-3B-Instruct-FP8/Llama-3.2-3B-Instruct-FP8 # 👈 update this ❗️❗️❗️

--- a/docs/11-maas/4-take-it-to-prod.md
+++ b/docs/11-maas/4-take-it-to-prod.md
@@ -165,7 +165,7 @@ Well, test first.
     ```yaml
 
     LLAMA_STACK_URL: "http://llama-stack-service:8321"
-    summarize:
+    summarization:
       enabled: true
       model: vllm-Llama-3.2-3B-Instruct-FP8/Llama-3.2-3B-Instruct-FP8 # 👈 Update this ❗︎❗︎
       temperature: 0.9

--- a/docs/12-fine-tuning/2-deploy-to-canopy.md
+++ b/docs/12-fine-tuning/2-deploy-to-canopy.md
@@ -135,7 +135,7 @@ Let's get this Socratic tutor fully set up in Canopy!
 
   ```yaml
   LLAMA_STACK_URL: "http://llama-stack-service:8321"
-  summarize:
+  summarization:
     enabled: true
     model: vllm-Llama-3.2-3B-Instruct-FP8/Llama-3.2-3B-Instruct-FP8
     temperature: 0.9

--- a/docs/old_5-grounded-ai/5-rag-canopyUI.md
+++ b/docs/old_5-grounded-ai/5-rag-canopyUI.md
@@ -10,7 +10,7 @@ The Canopy application we deployed already has RAG built-in as you may have seen
 
     ```yaml
     LLAMA_STACK_URL: "http://llama-stack-service:8321"
-    summarize:
+    summarization:
       enabled: true
       model: vllm-llama32/llama32
       temperature: 0.9


### PR DESCRIPTION
`canopy-backend` service has incorrect summarization reference.

Fix the typo to use the `summarization` string that was used from the beginning of the tutorial.

Closes https://github.com/rhoai-genaiops/lab-instructions/issues/196